### PR TITLE
fix bug 修改声音、实体、UI 编号从1开始 0为无效编号

### DIFF
--- a/GameFramework/Entity/EntityManager.cs
+++ b/GameFramework/Entity/EntityManager.cs
@@ -47,7 +47,7 @@ namespace GameFramework.Entity
             m_ObjectPoolManager = null;
             m_ResourceManager = null;
             m_EntityHelper = null;
-            m_Serial = 0;
+            m_Serial = 1;
             m_ShowEntitySuccessEventHandler = null;
             m_ShowEntityFailureEventHandler = null;
             m_ShowEntityUpdateEventHandler = null;

--- a/GameFramework/Sound/SoundManager.cs
+++ b/GameFramework/Sound/SoundManager.cs
@@ -39,7 +39,7 @@ namespace GameFramework.Sound
             m_LoadAssetCallbacks = new LoadAssetCallbacks(LoadSoundSuccessCallback, LoadSoundFailureCallback, LoadSoundUpdateCallback, LoadSoundDependencyAssetCallback);
             m_ResourceManager = null;
             m_SoundHelper = null;
-            m_Serial = 0;
+            m_Serial = 1;
             m_PlaySoundSuccessEventHandler = null;
             m_PlaySoundFailureEventHandler = null;
             m_PlaySoundUpdateEventHandler = null;

--- a/GameFramework/UI/UIManager.cs
+++ b/GameFramework/UI/UIManager.cs
@@ -49,7 +49,7 @@ namespace GameFramework.UI
             m_ResourceManager = null;
             m_InstancePool = null;
             m_UIFormHelper = null;
-            m_Serial = 0;
+            m_Serial = 1;
             m_OpenUIFormSuccessEventHandler = null;
             m_OpenUIFormFailureEventHandler = null;
             m_OpenUIFormUpdateEventHandler = null;


### PR DESCRIPTION
如果0为有效编号 sound 在非第一声音组的第一个音效将永远关不掉  实体和ui 被关闭清0的id 如果逻辑层还有释放会导致第一个加载的被错误关闭或销毁