### PR TITLE
解决重复回收会抛出异常

### DIFF
--- a/GameFramework/Entity/EntityManager.cs
+++ b/GameFramework/Entity/EntityManager.cs
@@ -1208,7 +1208,7 @@ namespace GameFramework.Entity
                 HideEntity(childEntity.Id, userData);
             }
 
-            if (entityInfo.Status == EntityStatus.Hidden)
+            if (entityInfo.Status == EntityStatus.WillHide || entityInfo.Status == EntityStatus.Hidden)
             {
                 return;
             }


### PR DESCRIPTION
如果在游戏逻辑中HideEntity，然后同时结束游戏，可能会同时触发两个HideEntity。

这样会导致EntityGroup中`m_Entities.Remove(entity)`时发生Exception，所以在WillHide时也应该不继续执行。